### PR TITLE
Add config option `search-by-title`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add new boolean config option `search-by-title`. If set to `true`, 
+  existing issues are searched using the issue title (`titleTemplate`) 
+  in addition to the `label-name`.
+
 ## v1.2.0 (2024-02-16)
 
 - Changed action to use [Node 20 runtime](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "If true, will always create a new issue, even if one matching 'label-name' is already open."
     required: true
     default: false
+  search-by-title:
+    description: "If true, search for an existing issue is based on the 'title-template' and the 'label-name'."
+    required: true
+    default: false
 # outputs will be available to future steps
 outputs:
   issue-number:

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ async function run() {
     const bodyTemplate = core.getInput('body-template');
     const createLabel = core.getBooleanInput('create-label');
     const alwaysCreateNewIssue = core.getBooleanInput('always-create-new-issue');
+    const searchByTitle = core.getBooleanInput('search-by-title');
 
     const { issueNumber, created } = await newIssueOrCommentForLabel(
       githubToken,
@@ -22,6 +23,7 @@ async function run() {
       bodyTemplate,
       createLabel,
       alwaysCreateNewIssue,
+      searchByTitle,
     )
     const htmlUrl = created.html_url
     core.info("Created url: " + htmlUrl);

--- a/tests/new-issue-or-comment-for-label.test.js
+++ b/tests/new-issue-or-comment-for-label.test.js
@@ -81,6 +81,43 @@ describe("Test newIssueOrCommentForLabel", () => {
       defaultBodyTemplate,
       true,
       false,
+      false,
+    )
+    expect(issueNumber).toBe(newIssueNumber);
+    expect(created).toBeTruthy();
+    return
+  });
+
+  it('should create new issue if no issues exist for title', async () => {
+    // Mock check if label exists
+    nock("https://api.github.com")
+      .get(`/repos/${testOwner}/${testRepo}/labels/${encodeURI(testLabel)}`)
+      .reply(200, {
+        owner: testOwner,
+        repo: testRepo,
+        name: testLabel,
+      });
+    // Mock search issues with title and label
+    nock("https://api.github.com")
+      .get(`/search/issues`)
+      .query(true)
+      .reply(200, []);
+    // Mock create new issue
+    const newIssueNumber = 100;
+    nock("https://api.github.com")
+      .post(`/repos/${testOwner}/${testRepo}/issues`)
+      .reply(200, {
+        number: newIssueNumber,
+      });
+
+    const { issueNumber, created } = await newIssueOrCommentForLabel(
+      "github_token_here",
+      testLabel,
+      defaultTitleTemplate,
+      defaultBodyTemplate,
+      true,
+      false,
+      true,
     )
     expect(issueNumber).toBe(newIssueNumber);
     expect(created).toBeTruthy();
@@ -122,6 +159,49 @@ describe("Test newIssueOrCommentForLabel", () => {
       defaultBodyTemplate,
       true,
       false,
+      false,
+    )
+    expect(issueNumber).toBe(existingIssueNumber);
+    expect(created).toBeTruthy();
+    return
+  });
+
+  it('should add comment to existing issue for title and label', async () => {
+    // Mock check if label exists
+    nock("https://api.github.com")
+      .get(`/repos/${testOwner}/${testRepo}/labels/${encodeURI(testLabel)}`)
+      .reply(200, {
+        owner: testOwner,
+        repo: testRepo,
+        name: testLabel,
+      });
+    // Mock search issues with title and label
+    const existingIssueNumber = 1;
+    nock("https://api.github.com")
+      .get(`/search/issues`)
+      .query(true)
+      .reply(200, [
+        {
+          number: existingIssueNumber,
+        }
+      ]);
+    // Mock create comment on existing issue
+    nock("https://api.github.com")
+      .post(`/repos/${testOwner}/${testRepo}/issues/${existingIssueNumber}/comments`)
+      .reply(200,
+        {
+          id: 1,
+        }
+      );
+
+    const { issueNumber, created } = await newIssueOrCommentForLabel(
+      "github_token_here",
+      testLabel,
+      defaultTitleTemplate,
+      defaultBodyTemplate,
+      true,
+      false,
+      true,
     )
     expect(issueNumber).toBe(existingIssueNumber);
     expect(created).toBeTruthy();
@@ -162,6 +242,7 @@ describe("Test newIssueOrCommentForLabel", () => {
       defaultBodyTemplate,
       false,
       true,
+      false,
     )
     expect(issueNumber).toBe(newIssueNumber);
     expect(created).toBeTruthy();
@@ -197,6 +278,7 @@ describe("Test newIssueOrCommentForLabel", () => {
       defaultBodyTemplate,
       false,
       true,
+      false,
     )
     expect(issueNumber).toBe(newIssueNumber);
     expect(created).toBeTruthy();
@@ -217,6 +299,7 @@ describe("Test newIssueOrCommentForLabel", () => {
         testLabel,
         defaultTitleTemplate,
         defaultBodyTemplate,
+        false,
         false,
         false,
       )
@@ -258,6 +341,7 @@ describe("Test newIssueOrCommentForLabel", () => {
       defaultBodyTemplate,
       true,
       false,
+      false,
     )
     expect(issueNumber).toBe(newIssueNumber);
     expect(created).toBeTruthy();
@@ -278,6 +362,7 @@ describe("Test newIssueOrCommentForLabel", () => {
         testLabel,
         defaultTitleTemplate,
         defaultBodyTemplate,
+        false,
         false,
         false,
       )


### PR DESCRIPTION
If set to `true`, existing issues are searched using the issue title (`titleTemplate`) in addition to the `label-name`.